### PR TITLE
Remove deprecated "version" attribute in docker-compose.yml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   alloy:
     image: grafana/alloy:v1.7.5


### PR DESCRIPTION
Hi! Just wanted to create one small PR for a small fix. Let me know if you find everything correct or if you prefer an issue first!

The change just removes the `version` label in the `docker-compose.yml` file. When the `docker compose up -d` step is executed, a warning is shown. Looks like the attribute was deprecated a while ago: https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete. This PR removes the attribute so the warning is not shown again.

```
WARN[0000] /Users/.../adventure/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```

I'm using MacOS Sequoia 15.5, Docker version 28.1.1 build 4eba377

